### PR TITLE
Removing the master-slave language

### DIFF
--- a/lib/python2.7/site-packages/boto/elastictranscoder/layer1.py
+++ b/lib/python2.7/site-packages/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/lib/python2.7/site-packages/boto/emr/connection.py
+++ b/lib/python2.7/site-packages/boto/emr/connection.py
@@ -204,8 +204,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -231,11 +231,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -266,7 +266,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -316,15 +316,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -487,15 +487,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/lib/python2.7/site-packages/boto/emr/step.py
+++ b/lib/python2.7/site-packages/boto/emr/step.py
@@ -130,7 +130,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/lib/python2.7/site-packages/boto/opsworks/layer1.py
+++ b/lib/python2.7/site-packages/boto/opsworks/layer1.py
@@ -532,8 +532,8 @@ class OpsWorksConnection(AWSQueryConnection):
         + php-app: A PHP App Server layer
         + nodejs-app: A Node.js App Server layer
         + memcached: A Memcached layer
-        + db-master: A MySQL layer
-        + monitoring-master: A Ganglia layer
+        + db-main: A MySQL layer
+        + monitoring-main: A Ganglia layer
         + custom: A custom layer
 
         :type name: string

--- a/lib/python2.7/site-packages/boto/pyami/bootstrap.py
+++ b/lib/python2.7/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/lib/python2.7/site-packages/boto/rds/__init__.py
+++ b/lib/python2.7/site-packages/boto/rds/__init__.py
@@ -146,8 +146,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -175,8 +175,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -225,8 +225,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-ex
                        * sqlserver-web
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -243,8 +243,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -383,8 +383,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -405,8 +405,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -499,7 +499,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -527,8 +527,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -597,8 +597,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/lib/python2.7/site-packages/boto/rds/dbinstance.py
+++ b/lib/python2.7/site-packages/boto/rds/dbinstance.py
@@ -43,7 +43,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -83,7 +83,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -143,8 +143,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -258,7 +258,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -281,8 +281,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -342,7 +342,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/lib/python2.7/site-packages/boto/rds/dbsnapshot.py
+++ b/lib/python2.7/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     """
 
     def __init__(self, connection=None, id=None):
@@ -49,7 +49,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -77,8 +77,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/lib/python2.7/site-packages/boto/redshift/layer1.py
+++ b/lib/python2.7/site-packages/boto/redshift/layer1.py
@@ -250,8 +250,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -328,9 +328,9 @@ class RedshiftConnection(AWSQueryConnection):
             the Amazon Redshift Management Guide .
         Valid Values: `dw.hs1.xlarge` | `dw.hs1.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -341,9 +341,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -489,8 +489,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -1549,7 +1549,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -1557,7 +1557,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying parameter group requires a reboot for parameters to
@@ -1637,15 +1637,15 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of Virtual Private Cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
         Operations never return the password, so this operation provides a way
-            to regain access to the master user account for a cluster if the
+            to regain access to the main user account for a cluster if the
             password is lost.
 
 
@@ -1734,8 +1734,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/lib/python2.7/site-packages/django/conf/global_settings.py
+++ b/lib/python2.7/site-packages/django/conf/global_settings.py
@@ -218,7 +218,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/lib/python2.7/site-packages/django/contrib/localflavor/mk/forms.py
+++ b/lib/python2.7/site-packages/django/contrib/localflavor/mk/forms.py
@@ -39,10 +39,10 @@ class MKMunicipalitySelect(Select):
 
 class UMCNField(RegexField):
     """
-    A form field that validates input as a unique master citizen
+    A form field that validates input as a unique main citizen
     number.
 
-    The format of the unique master citizen number has been kept the same from
+    The format of the unique main citizen number has been kept the same from
     Yugoslavia. It is still in use in other countries as well, it is not applicable
     solely in Macedonia. For more information see:
     https://secure.wikimedia.org/wikipedia/en/wiki/Unique_Master_Citizen_Number

--- a/lib/python2.7/site-packages/django/contrib/localflavor/mk/models.py
+++ b/lib/python2.7/site-packages/django/contrib/localflavor/mk/models.py
@@ -32,7 +32,7 @@ class MKMunicipalityField(CharField):
 
 class UMCNField(CharField):
 
-    description = _("Unique master citizen number (13 digits)")
+    description = _("Unique main citizen number (13 digits)")
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 13

--- a/lib/python2.7/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/lib/python2.7/site-packages/django/db/backends/sqlite3/introspection.py
@@ -53,7 +53,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type='table' AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -73,7 +73,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -91,7 +91,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -118,7 +118,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -163,7 +163,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
         for field_desc in results.split(','):

--- a/lib/python2.7/site-packages/django/test/_doctest.py
+++ b/lib/python2.7/site-packages/django/test/_doctest.py
@@ -1521,7 +1521,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1815,7 +1815,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1877,13 +1877,13 @@ def testmod(m=None, name=None, globs=None, verbose=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     # If no module was given, then use __main__.
     if m is None:
@@ -1914,10 +1914,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1995,13 +1995,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -2037,10 +2037,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/lib/python2.7/site-packages/django/test/client.py
+++ b/lib/python2.7/site-packages/django/test/client.py
@@ -386,7 +386,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/lib/python2.7/site-packages/pip/vcs/git.py
+++ b/lib/python2.7/site-packages/pip/vcs/git.py
@@ -91,7 +91,7 @@ class Git(VersionControl):
     def update(self, dest, rev_options):
         # First fetch changes from the default remote
         call_subprocess([self.cmd, 'fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maby even origin/master)
+        # Then reset to wanted revision (maby even origin/main)
         if rev_options:
             rev_options = self.check_rev_options(rev_options[0], dest, rev_options)
         call_subprocess([self.cmd, 'reset', '--hard', '-q'] + rev_options, cwd=dest)
@@ -104,7 +104,7 @@ class Git(VersionControl):
             rev_options = [rev]
             rev_display = ' (to %s)' % rev
         else:
-            rev_options = ['origin/master']
+            rev_options = ['origin/main']
             rev_display = ''
         if self.check_destination(dest, url, rev_options, rev_display):
             logger.notify('Cloning %s%s to %s' % (url, rev_display, display_path(dest)))

--- a/lib/python2.7/site-packages/pkg_resources.py
+++ b/lib/python2.7/site-packages/pkg_resources.py
@@ -2994,7 +2994,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 try:
     # Does the main program list any requirements?

--- a/lib/python2.7/site-packages/setuptools/tests/doctest.py
+++ b/lib/python2.7/site-packages/setuptools/tests/doctest.py
@@ -1452,7 +1452,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1746,7 +1746,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1815,13 +1815,13 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if isprivate is not None:
         warnings.warn("the isprivate argument is deprecated; "
@@ -1857,10 +1857,10 @@ def testmod(m=None, name=None, globs=None, verbose=None, isprivate=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -1933,13 +1933,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -1977,10 +1977,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.